### PR TITLE
Split extra_parameters into a list

### DIFF
--- a/ping/checks.py
+++ b/ping/checks.py
@@ -15,6 +15,8 @@ def checks(request):
     # We want to preserve the order
     response_dict = OrderedDict()
     extra_parameters = request.GET.get('parameters')
+    if extra_parameters:
+        extra_parameters = extra_parameters.split(',')
 
     #Taken straight from Django
     #If there is a better way, I don't know it


### PR DESCRIPTION
Splitting into a list will prevent sub-strings being found in the extra_parameters string, such as ping_check_search being in ping_check_search_v2